### PR TITLE
misc: detect and use gdate when available

### DIFF
--- a/stup
+++ b/stup
@@ -57,17 +57,13 @@ DEFAULT_SHOW_AT="yesterday"
 DEFAULT_ADD_AT="today"
 DEFAULT_EDIT_AT="today"
 
-# Store the original date function as _date
-eval "`declare -f date | sed '1s/.*/_&/'`"
-
-# Determine which date function to use
-date() {
-  if hash gdate 2>/dev/null; then
+# Use gdate instead of date when available.
+if hash gdate 2>/dev/null; then
+  date()
+  {
     gdate "$@"
-  else
-    _date "$@"
-  fi
-}
+  }
+fi
 
 # Stup entry point
 stup()

--- a/stup
+++ b/stup
@@ -57,6 +57,18 @@ DEFAULT_SHOW_AT="yesterday"
 DEFAULT_ADD_AT="today"
 DEFAULT_EDIT_AT="today"
 
+# Store the original date function as _date
+eval "`declare -f date | sed '1s/.*/_&/'`"
+
+# Determine which date function to use
+date() {
+  if hash gdate 2>/dev/null; then
+    gdate "$@"
+  else
+    _date "$@"
+  fi
+}
+
 # Stup entry point
 stup()
 {


### PR DESCRIPTION
The GNU date function is different than the one on unix, so OSX users get all sorts of errors trying to do fancy date calculations with words like `today`.

```
~/git $ stup add -n "test"
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
Successfully added 1 notes in category work for 
```

This likely still requires OSX users to install `coreutils`, I'm not clear if that's a default installation or not. It's readily available on brew though if needed https://formulae.brew.sh/formula/coreutils