### PR TITLE
fix: version information available wo. config

### DIFF
--- a/stup
+++ b/stup
@@ -75,7 +75,7 @@ stup()
   resolve_configuration_file
   parse_options "$@"
 
-  if [ "$COMMAND" != "configure" ] && [ "$USAGE" != "true" ]; then
+  if [ "$COMMAND" != "configure" ] && [ "$USAGE" != "true" ] && [ "$COMMAND" != "version" ]; then
     ensure_configured
     load_configuration
   fi


### PR DESCRIPTION
This commit allows the version information to be shown without the
config file being in place yet.

Now `stup --version` will work even without the config file in place.